### PR TITLE
模版的名称跟随package.name字段。

### DIFF
--- a/config/h5.js
+++ b/config/h5.js
@@ -1,5 +1,6 @@
+const packageJson = require('../package.json')
 const config = {
-  projectName: 'my-app',
+  projectName: packageJson.name,
   date: '2019-2-21',
   designWidth: 750,
   deviceRatio: {

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,6 @@
+const packageJson = require('../package.json')
 const config = {
-  projectName: 'my-app',
+  projectName: packageJson.name,
   date: '2019-2-21',
   designWidth: 750,
   deviceRatio: {

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,9 @@
 
 import './app.css'
 import './pages/index/index'
-import { render, WeElement, define } from 'omi'
-
-define('my-app', class extends WeElement {
+import { render, WeElement, define, h } from 'omi'
+import packageJson from '../package.json'
+define(packageJson.name, class extends WeElement {
 
   config = {
     pages: [
@@ -70,4 +70,4 @@ define('my-app', class extends WeElement {
 })
 
 
-render(<my-app />, '#app')
+render(h(packageJson.name), '#app')


### PR DESCRIPTION
fixed https://github.com/Tencent/omi/issues/277

omi-cli 里下载模版的时候会更改packjson里的name,不过project.config.json里的name好像没改，如果可以的话，我过会修复一下？